### PR TITLE
Car and heart icons

### DIFF
--- a/components/ui/icons/car-icon.tsx
+++ b/components/ui/icons/car-icon.tsx
@@ -1,0 +1,39 @@
+/**
+ * CarIcon component
+ * Can be used both on buttons and as a pin/marker on the map
+ */
+
+import React from 'react';
+
+// Props for customizing the icon
+interface CarIconProps {
+  size?: number; // width & height (height scales proportionally)
+  color?: string; // stroke/fill color
+  className?: string; // optional extra CSS classes
+}
+
+// Car icon
+export const CarIcon: React.FC<CarIconProps> = ({
+  size = 24,
+  color = '#819A79',
+  className = '',
+}) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width={size}
+    height={size} // original viewBox is square, so width = height
+    viewBox="0 0 24 24"
+    fill="none"
+    className={className}
+  >
+    <rect x="0.25" y="0.25" width="23.5" height="23.5" rx="2.75" stroke={color} strokeWidth="0.5" />
+    <path
+      d="M6 19V20C6 20.2833 5.90417 20.5208 5.7125 20.7125C5.52083 20.9042 5.28333 21 5 21H4C3.71667 21 3.47917 20.9042 3.2875 20.7125C3.09583 20.5208 3 20.2833 3 20V12L5.1 6C5.2 5.7 5.37917 5.45833 5.6375 5.275C5.89583 5.09167 6.18333 5 6.5 5H17.5C17.8167 5 18.1042 5.09167 18.3625 5.275C18.6208 5.45833 18.8 5.7 18.9 6L21 12V20C21 20.2833 20.9042 20.5208 20.7125 20.7125C20.5208 20.9042 20.2833 21 20 21H19C18.7167 21 18.4792 20.9042 18.2875 20.7125C18.0958 20.5208 18 20.2833 18 20V19H6ZM5.8 10H18.2L17.15 7H6.85L5.8 10ZM7.5 16C7.91667 16 8.27083 15.8542 8.5625 15.5625C8.85417 15.2708 9 14.9167 9 14.5C9 14.0833 8.85417 13.7292 8.5625 13.4375C8.27083 13.1458 7.91667 13 7.5 13C7.08333 13 6.72917 13.1458 6.4375 13.4375C6.14583 13.7292 6 14.0833 6 14.5C6 14.9167 6.14583 15.2708 6.4375 15.5625C6.72917 15.8542 7.08333 16 7.5 16ZM16.5 16C16.9167 16 17.2708 15.8542 17.5625 15.5625C17.8542 15.2708 18 14.9167 18 14.5C18 14.0833 17.8542 13.7292 17.5625 13.4375C17.2708 13.1458 16.9167 13 16.5 13C16.0833 13 15.7292 13.1458 15.4375 13.4375C15.1458 13.7292 15 14.0833 15 14.5C15 14.9167 15.1458 15.2708 15.4375 15.5625C15.7292 15.8542 16.0833 16 16.5 16ZM5 17H19V12H5V17Z"
+      fill={color}
+    />
+  </svg>
+);
+
+/** Usage example:
+ *   <CarIcon size={24} color="#819A79" />
+ */

--- a/components/ui/icons/heart-icon.tsx
+++ b/components/ui/icons/heart-icon.tsx
@@ -1,0 +1,38 @@
+/**
+ * HeartIcon component
+ * Can be used both on buttons and as a pin/marker on the map
+ */
+import React from 'react';
+
+// Props for customizing the icon
+interface HeartIconProps {
+  size?: number; // width & height of the icon
+  color?: string; // fill color
+  className?: string; // optional extra CSS classes
+}
+
+// Heart icon
+export const HeartIcon: React.FC<HeartIconProps> = ({
+  size = 15,
+  color = '#63705B',
+  className = '',
+}) => (
+  <svg
+    xmlns="xhttp://www.w3.org/2000/svg"
+    width={size}
+    height={(size * 13) / 15} // keeps original aspect ratio 15x13
+    viewBox="0 0 15 13"
+    fill="none"
+    className={className}
+  >
+    <path
+      d="M13.6647 1.14171C13.3029 0.779755 12.8733 0.492626 12.4005 0.296728C11.9278 0.100829 11.421 0 10.9092 0C10.3975 0 9.89074 0.100829 9.41795 0.296728C8.94517 0.492626 8.51562 0.779755 8.15383 1.14171L7.403 1.89254L6.65216 1.14171C5.92138 0.410928 4.93023 0.00037879 3.89675 0.000378797C2.86327 0.000378805 1.87211 0.410928 1.14133 1.14171C0.410549 1.87249 7.70004e-09 2.86364 0 3.89713C-7.70004e-09 4.93061 0.410549 5.92176 1.14133 6.65254L7.403 12.9142L13.6647 6.65254C14.0266 6.29076 14.3137 5.8612 14.5096 5.38842C14.7055 4.91564 14.8064 4.40889 14.8064 3.89713C14.8064 3.38536 14.7055 2.87862 14.5096 2.40583C14.3137 1.93305 14.0266 1.5035 13.6647 1.14171Z"
+      fill={color}
+    />
+  </svg>
+);
+
+/**
+ * Usage example:
+ *   <HeartIcon size={24} color="#63705B" />
+ */


### PR DESCRIPTION
Added car and heart components, to later be used for
- bookmark and parking pins
- icon on the "bookmark this spot" and "just parked here" buttons!

Here is what they look like in their default color, **but don't worry they are not actually placed there in the code**:
<img width="612" height="286" alt="Screenshot 2025-10-28 at 10 08 37 PM" src="https://github.com/user-attachments/assets/30db2a90-5f0c-45b2-a11d-12b094028b2c" />
